### PR TITLE
Disable client's UUID

### DIFF
--- a/scripts/jenkins-slave/jenkins-slave
+++ b/scripts/jenkins-slave/jenkins-slave
@@ -72,4 +72,4 @@ PREFIX=/$NAME
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 
-JENKINS_SWARM_ARGS="-master http://${JENKINS_MASTER} -fsroot ${JENKINS_HOME} -name ${JENKINS_SLAVE} -username ${JENKINS_USERNAME} -password ${JENKINS_TOKEN}"
+JENKINS_SWARM_ARGS="-master http://${JENKINS_MASTER} -disableClientsUniqueId -fsroot ${JENKINS_HOME} -name ${JENKINS_SLAVE} -username ${JENKINS_USERNAME} -password ${JENKINS_TOKEN}"


### PR DESCRIPTION
Add the flag to disable the appending of a client's UUID to a Jenkins
node name.

Fixes: Issue #3 
