### PR TITLE
Issue 07

### DIFF
--- a/inventory/group_vars/eng-iad3-lab02.yml
+++ b/inventory/group_vars/eng-iad3-lab02.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: eng-iad3-lab02
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-lab03.yml
+++ b/inventory/group_vars/fcfs-iad3-lab03.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-lab03
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-lab06.yml
+++ b/inventory/group_vars/fcfs-iad3-lab06.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-lab06
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-storage01.yml
+++ b/inventory/group_vars/fcfs-iad3-storage01.yml
@@ -1,4 +1,6 @@
 ---
+lab_name: fcfs-iad3-storage01
+
 networking:
   - name: lo
     type: loopback

--- a/inventory/group_vars/fcfs-iad3-storage04.yml
+++ b/inventory/group_vars/fcfs-iad3-storage04.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-storage04
 config_prefix: openstack
 repo_dir: openstack-ansible
 standalone_swift: true

--- a/inventory/group_vars/fcfs-syd2-lab01.yml
+++ b/inventory/group_vars/fcfs-syd2-lab01.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-syd2-lab01
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/qe-iad3-lab01.yml
+++ b/inventory/group_vars/qe-iad3-lab01.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: qe-iad3-lab01
 config_prefix: openstack
 repo_dir: rpc-openstack
 rpc_ceph: true

--- a/inventory/group_vars/sat6-full-ceph.yml
+++ b/inventory/group_vars/sat6-full-ceph.yml
@@ -1,5 +1,6 @@
 ---
 # Repo Config
+lab_name: sat6-full-ceph
 config_prefix: openstack
 repo_dir: openstack_repo
 razor_url: http://10.127.101.82:8080/api

--- a/inventory/group_vars/sat6-full.yml
+++ b/inventory/group_vars/sat6-full.yml
@@ -1,5 +1,6 @@
 ---
 # Repo Config
+lab_name: sat6-full
 config_prefix: openstack
 repo_dir: openstack_repo
 razor_url: http://10.127.101.82:8080/api

--- a/roles/configure-compute/tasks/main.yml
+++ b/roles/configure-compute/tasks/main.yml
@@ -27,11 +27,6 @@
     rsync_opts:
       - "--ignore-existing"
 
-- name: Gather environment MD5
-  stat:
-    path: /etc/{{ config_prefix }}_deploy/{{ config_prefix }}_environment.yml
-  register: environment_version
-
 - name: Install user configuration file
   template:
     src: user_config.j2

--- a/roles/configure-compute/templates/user_config.j2
+++ b/roles/configure-compute/templates/user_config.j2
@@ -8,10 +8,6 @@
 {% set haproxy = groups[lab_name + '-haproxy'] %}
 {% endif %}
 
-# This is the md5 of the environment file
-# this will ensure consistency when deploying.
-environment_version: {{ environment_version.stat.md5 }}
-
 # User defined CIDR used for containers
 # Global cidr/s used for everything.
 cidr_networks:

--- a/roles/configure-rpc/tasks/main.yml
+++ b/roles/configure-rpc/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Copy RPC rpcd/etc configuration files
   shell: "cp {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/{{ item }} /etc/{{ config_prefix }}_deploy/"
   with_items:
-    - user_extras_secrets.yml
-    - user_extras_variables.yml
+    - user_rpco_secrets.yml
+    - user_rpco_variables_defaults.yml
 
 - name: Copy RPC rpcd/env.d variable files
   shell: "cp {{ product_repo_dir }}/rpcd/etc/{{ config_prefix }}_deploy/env.d/* /etc/{{ config_prefix }}_deploy/env.d/"


### PR DESCRIPTION
- Rename RPC-O extras files
- Remove environment MD5 as dependent files and upstream variables no longer exist.
- Set lab name variable per group

Usage: `ansible-playbook site.yml --limit server-XX-deployment --extra-vars="product=rpc-openstack"`

Fixes: Issue #7
