### PR TITLE
Update OSA configuration file sources

### DIFF
--- a/roles/configure-compute/tasks/main.yml
+++ b/roles/configure-compute/tasks/main.yml
@@ -13,16 +13,16 @@
     oa_repo_dir: "{{ product_repo_dir }}"
   when: product == "openstack-ansible"
 
-- name: Create OA configuration directory
+- name: Create OA environment directory
   file:
-    path: /etc/{{ config_prefix }}_deploy/
+    path: /etc/{{ config_prefix }}_deploy/env.d
     state: directory
     mode: 0755
 
-- name: Copy OA configuration files
+- name: Copy OA environment files
   synchronize:
-    src: "{{ oa_repo_dir }}/etc/{{ config_prefix }}_deploy/"
-    dest: "/etc/{{ config_prefix }}_deploy"
+    src: "{{ oa_repo_dir }}/etc/{{ config_prefix }}_deploy/env.d/"
+    dest: "/etc/{{ config_prefix }}_deploy/env.d"
     recursive: yes
     rsync_opts:
       - "--ignore-existing"
@@ -39,12 +39,10 @@
 
 - name: Create passphrases file
   file:
-    path: /etc/{{ config_prefix }}_deploy/user_secrets.yml
+    path: /etc/{{ config_prefix }}_deploy/user_osa_secrets.yml
     state: touch
     owner: root
     mode: 0644
 
 - name: Generate passphrases
-  command: "{{ oa_repo_dir }}/scripts/pw-token-gen.py --file /etc/{{ config_prefix }}_deploy/user_secrets.yml"
-  args:
-    creates: "/etc/{{ config_prefix }}_deploy/user_secrets.yml"
+  command: "{{ oa_repo_dir }}/scripts/pw-token-gen.py --file /etc/{{ config_prefix }}_deploy/user_osa_secrets.yml"


### PR DESCRIPTION
Copy only the OSA environment files. Generate passwords with the new
RPC-O filename as the destination.

Fixes: Issue #9
