### PR TITLE
Update LVM driver name

### DIFF
--- a/inventory/group_vars/eng-iad3-lab02.yml
+++ b/inventory/group_vars/eng-iad3-lab02.yml
@@ -97,7 +97,7 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # all networking interface configs

--- a/inventory/group_vars/fcfs-iad3-lab03.yml
+++ b/inventory/group_vars/fcfs-iad3-lab03.yml
@@ -96,7 +96,7 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # all networking interface configs

--- a/inventory/group_vars/fcfs-iad3-lab06.yml
+++ b/inventory/group_vars/fcfs-iad3-lab06.yml
@@ -81,7 +81,7 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # all networking interface configs

--- a/inventory/group_vars/fcfs-syd2-lab01.yml
+++ b/inventory/group_vars/fcfs-syd2-lab01.yml
@@ -119,7 +119,7 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # all networking interface configs

--- a/inventory/group_vars/qe-iad3-lab01.yml
+++ b/inventory/group_vars/qe-iad3-lab01.yml
@@ -65,7 +65,7 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 swift_config:

--- a/inventory/group_vars/qe-iad3-lab02.yml
+++ b/inventory/group_vars/qe-iad3-lab02.yml
@@ -87,11 +87,11 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
     lvm_ssd:
       volume_group: cinder-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # Swift Config

--- a/inventory/group_vars/qe-iad3-lab03.yml
+++ b/inventory/group_vars/qe-iad3-lab03.yml
@@ -83,11 +83,11 @@ cinder_storage:
   backends:
     lvm:
       volume_group: storage-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
     lvm_ssd:
       volume_group: storage-volumes
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
 
 # Swift Config

--- a/inventory/group_vars/sat6-full-ceph.yml
+++ b/inventory/group_vars/sat6-full-ceph.yml
@@ -82,11 +82,11 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volume-hdd
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
     lvm_ssd:
       volume_group: cinder-volume-ssd
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSISSD
 
 # Swift Config

--- a/inventory/group_vars/sat6-full.yml
+++ b/inventory/group_vars/sat6-full.yml
@@ -96,11 +96,11 @@ cinder_storage:
   backends:
     lvm:
       volume_group: cinder-volume-hdd
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSI
     lvm_ssd:
       volume_group: cinder-volume-ssd
-      volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       volume_backend_name: LVM_iSCSISSD
 
 # Swift Config

--- a/roles/configure-compute/templates/backends.j2
+++ b/roles/configure-compute/templates/backends.j2
@@ -5,7 +5,7 @@ container_vars:
     limit_container_types: cinder_volume
     lvm:
       volume_group: {{ volume_group }}
-      driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       backend_name: LVM_iSCSI
 {% endblock %}
 {% block netapp %}

--- a/roles/configure-rpc/templates/backends.j2
+++ b/roles/configure-rpc/templates/backends.j2
@@ -5,7 +5,7 @@ container_vars:
     limit_container_types: cinder_volume
     lvm:
       volume_group: {{ volume_group }}
-      driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+      driver: cinder.volume.drivers.lvm.LVMVolumeDriver
       backend_name: LVM_iSCSI
 {% endblock %}
 {% block netapp %}


### PR DESCRIPTION
Change LVM driver name from `cinder.volume.drivers.lvm.LVMISCSIDriver`
to `cinder.volume.drivers.lvm.LVMVolumeDriver`. The former no longer
exists in Mitaka.

Fixes: Issue #21
