### PR TITLE
Allow 'tempest_private_net' to be optional

### DIFF
--- a/roles/configure-rpc/templates/user_osa_variables_overrides.j2
+++ b/roles/configure-rpc/templates/user_osa_variables_overrides.j2
@@ -28,7 +28,7 @@ tempest_public_subnet_cidr: "{{ tempest_public_provider_net.tempest_public_subne
 tempest_public_subnet_gateway: "{{ tempest_public_provider_net.tempest_public_subnet_gateway }}"
 {% endif %}
 
-{% if tempest_private_net %}
+{% if tempest_private_net is defined %}
 tempest_private_subnet_cidr: "{{ tempest_private_net.tempest_private_subnet_cidr }}"
 tempest_private_net_provider_type: "{{ tempest_private_net.tempest_private_net_provider_type }}"
 tempest_private_net_seg_id: "{{ tempest_private_net.tempest_private_net_seg_id }}"


### PR DESCRIPTION
Adds 'is defined' portion to the 'if' statement. This adds the correct
syntax for making the variable optional.

Fixes: Issue #28
