### PR TITLE
Update FCFS-IAD3-STORAGE04 network information

### DIFF
--- a/inventory/group_vars/fcfs-iad3-storage04.yml
+++ b/inventory/group_vars/fcfs-iad3-storage04.yml
@@ -6,15 +6,16 @@ standalone_swift: true
 
 user_config:
   container_cidr: 172.20.236.0/22
+  container_cidr: 192.168.2.0/24
   storage_cidr:  172.30.244.0/22
   repl_cidr: 192.168.1.0/24
   used_ips:
-    - "172.20.236.1,172.20.236.15"
-    - "172.20.236.144,172.20.236.148"
+    - "192.168.2.1,192.168.2.15"
+    - "192.168.2.144,192.168.2.148"
     - "172.30.244.144,172.30.244.148"
     - "192.168.1.144,192.168.1.148"
-  internal_lb_vip_address: 172.20.236.10
-  external_lb_vip_address: 72.4.117.93
+  internal_lb_vip_address: 192.168.2.10
+  external_lb_vip_address: 173.203.145.68
   container_bridge: br-mgmt
   lb_name: 605010-lbal1.iad3.rpchost.com
   networking:
@@ -31,7 +32,7 @@ user_config:
         - all_containers
         - hosts
       static_routes:
-        - cidr: "172.20.136.0/22"
+        - cidr: "172.20.136.0/24"
           gateway: "172.20.236.1"
     - name: storage
       bridge: br-storage
@@ -149,7 +150,7 @@ networking:
       - "bridge_waitport 0"
       - "bridge_fd 0"
       - "bridge_ports bond0.2074"
-      - "address 172.20.236.{{ member_number }}/22"
+      - "address 192.168.2.{{ member_number }}/24"
       - "dns-nameservers 69.20.0.164 69.20.0.196"
       # Add the routes
       - "post-up ip route add 172.20.136.0/22 via 172.20.236.1"


### PR DESCRIPTION
Update the `FCFS-IAD3-STORAGE04` lab with new networking information available within LEM. The host routing has remained in-place, but has been deemed unnecessary by the NetOps team. All VPN routing is managed by the F5 load balancers.

Documentation on this feature is being done by the same team for future multi-region Swift customers.