### PR TITLE
Liberty Standalone/Multi-Region Swift backports

### DIFF
--- a/inventory/group_vars/eng-iad3-lab02.yml
+++ b/inventory/group_vars/eng-iad3-lab02.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: eng-iad3-lab02
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-lab03.yml
+++ b/inventory/group_vars/fcfs-iad3-lab03.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-lab03
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-lab06.yml
+++ b/inventory/group_vars/fcfs-iad3-lab06.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-lab06
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/fcfs-iad3-storage01.yml
+++ b/inventory/group_vars/fcfs-iad3-storage01.yml
@@ -1,4 +1,6 @@
 ---
+lab_name: fcfs-iad3-storage01
+
 networking:
   - name: lo
     type: loopback

--- a/inventory/group_vars/fcfs-iad3-storage04.yml
+++ b/inventory/group_vars/fcfs-iad3-storage04.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-iad3-storage04
 config_prefix: openstack
 repo_dir: openstack-ansible
 standalone_swift: true

--- a/inventory/group_vars/fcfs-iad3-storage04.yml
+++ b/inventory/group_vars/fcfs-iad3-storage04.yml
@@ -69,11 +69,9 @@ swift_config:
   storage_network: 'br-storage'
   replication_network: 'br-repl'
   drives:
-    - name: swift1
-    - name: swift2
-    - name: swift3
-    - name: swift4
-    - name: swift5
+    - name: sdb
+    - name: sdc
+    - name: sdd
   lv_size: 50G
   mount_point: /mnt
   mount_opts: 'noatime,nodiratime,nobarrier,logbufs=8,nobootwait'
@@ -191,11 +189,3 @@ networking:
       - "address {{ ansible_em3.ipv4.address }}"
       - "netmask {{ ansible_em3.ipv4.netmask }}"
       - "post-up ip route add 10.191.192.0/18 via 10.136.157.225 dev em3"
-
-# volume groups for cinder / swift
-vgs:
-  - name: swift-volumes
-    device:
-      - /dev/sdb
-      - /dev/sdc
-      - /dev/sdd

--- a/inventory/group_vars/fcfs-iad3-storage04.yml
+++ b/inventory/group_vars/fcfs-iad3-storage04.yml
@@ -5,16 +5,16 @@ repo_dir: openstack-ansible
 standalone_swift: true
 
 user_config:
-  container_cidr: 172.20.236.0/22
+  container_cidr: 192.168.2.0/24
   storage_cidr:  172.30.244.0/22
   repl_cidr: 192.168.1.0/24
   used_ips:
-    - "172.20.236.1,172.20.236.15"
-    - "172.20.236.144,172.20.236.148"
+    - "192.168.2.1,192.168.2.15"
+    - "192.168.2.144,192.168.2.148"
     - "172.30.244.144,172.30.244.148"
     - "192.168.1.144,192.168.1.148"
-  internal_lb_vip_address: 172.20.236.10
-  external_lb_vip_address: 72.4.117.93
+  internal_lb_vip_address: 192.168.2.10
+  external_lb_vip_address: 173.203.145.68
   container_bridge: br-mgmt
   lb_name: 605010-lbal1.iad3.rpchost.com
   networking:
@@ -31,7 +31,7 @@ user_config:
         - all_containers
         - hosts
       static_routes:
-        - cidr: "172.20.136.0/22"
+        - cidr: "172.20.136.0/24"
           gateway: "172.20.236.1"
     - name: storage
       bridge: br-storage
@@ -149,7 +149,7 @@ networking:
       - "bridge_waitport 0"
       - "bridge_fd 0"
       - "bridge_ports bond0.2074"
-      - "address 172.20.236.{{ member_number }}/22"
+      - "address 192.168.2.{{ member_number }}/24"
       - "dns-nameservers 69.20.0.164 69.20.0.196"
       # Add the routes
       - "post-up ip route add 172.20.136.0/22 via 172.20.236.1"

--- a/inventory/group_vars/fcfs-syd2-lab01.yml
+++ b/inventory/group_vars/fcfs-syd2-lab01.yml
@@ -85,15 +85,9 @@ vgs:
     device:
       - /dev/sdb
       - /dev/sdc
-  - name: swift-volumes
-    device:
-      - /dev/sdd
-      - /dev/sde
-      - /dev/sdf
 
 # all swift configuration
 swift_config:
-    vg: swift-volumes
     part_power: 8
     weight: 100
     repl_number: 3
@@ -102,11 +96,9 @@ swift_config:
     storage_network: 'br-storage'
     replication_network: 'br-repl'
     drives:
-      - name: swift1
-      - name: swift2
-      - name: swift3
-      - name: swift4
-      - name: swift5
+      - name: sdd
+      - name: sde
+      - name: sdf
     lv_size: 50G
     mount_point: /mnt
     mount_opts: 'noatime,nodiratime,nobarrier,logbufs=8,nobootwait'

--- a/inventory/group_vars/fcfs-syd2-lab01.yml
+++ b/inventory/group_vars/fcfs-syd2-lab01.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: fcfs-syd2-lab01
 config_prefix: openstack
 repo_dir: openstack-ansible
 

--- a/inventory/group_vars/qe-iad3-lab01.yml
+++ b/inventory/group_vars/qe-iad3-lab01.yml
@@ -1,4 +1,5 @@
 ---
+lab_name: qe-iad3-lab01
 config_prefix: openstack
 repo_dir: rpc-openstack
 rpc_ceph: true

--- a/inventory/group_vars/sat6-full-ceph.yml
+++ b/inventory/group_vars/sat6-full-ceph.yml
@@ -1,5 +1,6 @@
 ---
 # Repo Config
+lab_name: sat6-full-ceph
 config_prefix: openstack
 repo_dir: openstack_repo
 razor_url: http://10.127.101.82:8080/api

--- a/inventory/group_vars/sat6-full.yml
+++ b/inventory/group_vars/sat6-full.yml
@@ -1,5 +1,6 @@
 ---
 # Repo Config
+lab_name: sat6-full
 config_prefix: openstack
 repo_dir: openstack_repo
 razor_url: http://10.127.101.82:8080/api


### PR DESCRIPTION
Four back ports required for Swift compatibility between upgrades. This PR's been tested in the `FCFS-IAD3-STORAGE04` and `FCFS-SYD2-LAB01` labs.