### PR TITLE
Rename Jenkins slave inputs to reflect GitHub authentication tokens

### DIFF
--- a/scripts/jenkins-slave/setup.sh
+++ b/scripts/jenkins-slave/setup.sh
@@ -38,12 +38,12 @@ if [ -z "$JENKINS_SLAVE" ]; then
 fi
 
 if [ -z "$JENKINS_USERNAME" ]; then
-    echo "Enter the Jenkins username: "
+    echo "Enter your GitHub username: "
     read -r JENKINS_USERNAME
 fi
 
 if [ -z "$JENKINS_TOKEN" ]; then
-    echo "Enter the Jenkins slave secret: "
+    echo "Enter your GitHub personal authentication token: "
     read -rs JENKINS_TOKEN
 fi
 


### PR DESCRIPTION
Changed the input names to be less misleading on the actual backend
system being used for Jenkins Swarm authentication. This has proven to
be confusing in the past by end-users.

Our documentation has been updated to reflect this change as well.

Fixes: Issue #36