### PR TITLE
Using exclusive mode so slave only builds jobs assigned to its label

### DIFF
--- a/scripts/jenkins-slave/jenkins-slave
+++ b/scripts/jenkins-slave/jenkins-slave
@@ -72,4 +72,4 @@ PREFIX=/$NAME
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 
-JENKINS_SWARM_ARGS="-master http://${JENKINS_MASTER} -disableClientsUniqueId -fsroot ${JENKINS_HOME} -name ${JENKINS_SLAVE} -username ${JENKINS_USERNAME} -password ${JENKINS_TOKEN}"
+JENKINS_SWARM_ARGS="-master http://${JENKINS_MASTER} -disableClientsUniqueId -fsroot ${JENKINS_HOME} -name ${JENKINS_SLAVE} -username ${JENKINS_USERNAME} -password ${JENKINS_TOKEN} -mode exclusive -executors 15"


### PR DESCRIPTION
This'll make the default usage to be "only build jobs with label expressions matching this node" rather than "use this node as much as possible" so we don't accidentally run other jobs on the labs/OnMetal slaves. I added the number of executors too since the node I tested on started with only one executor by default after I added the -mode argument.