### PR TITLE
Fix FCFS-IAD3-LAB06 provider network VLAN ranges

### DIFF
--- a/inventory/group_vars/fcfs-iad3-lab06.yml
+++ b/inventory/group_vars/fcfs-iad3-lab06.yml
@@ -35,7 +35,7 @@ user_config:
           container_interface: eth11
           container_type: veth
           type: vlan
-          range: 235
+          range: 235:235
           net_name: vlan
           group_binds:
             - neutron_linuxbridge_agent


### PR DESCRIPTION
Add a second provider network VLAN range value. Neutron will then parse
the configuration correctly and recognize the network.

Fixes: Issue #44