### PR TITLE
Add retry limit for `do-until` loops

### DIFF
--- a/roles/kernel/tasks/main.yml
+++ b/roles/kernel/tasks/main.yml
@@ -10,6 +10,7 @@
     - linux-image-generic
   register: pkgs
   until: pkgs|success
+  retries: 3
 
 - name: restart machine
   command: shutdown -r now "Ansible kernel updates triggered"

--- a/roles/networking/tasks/main.yml
+++ b/roles/networking/tasks/main.yml
@@ -7,6 +7,7 @@
     cache_valid_time: 600
   register: pkgs
   until: pkgs|success
+  retries: 3
   with_items:
     - ifenslave-2.6
     - bridge-utils

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -14,6 +14,7 @@
     cache_valid_time: 600
   register: pkgs
   until: pkgs|success
+  retries: 3
 
 - name: Install packages
   tags: packages
@@ -24,4 +25,5 @@
     cache_valid_time: 600
   register: pkgs
   until: pkgs|success
+  retries: 3
   with_items: '{{ install }}'

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -7,3 +7,4 @@
     upgrade: safe
   register: pkgs
   until: pkgs|success
+  retries: 3


### PR DESCRIPTION
Required as a manual workaround for an Ansible 2.1 bug.

Fixes: Issue #50